### PR TITLE
Adding back minimum perl version.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ include_authors = 1
 -remove = Readme
 
 [@Git]
+[MinimumPerlFast]
 [MetaJSON]
 
 [MetaProvides::Package]


### PR DESCRIPTION
Hi @reneeb 

Please review the PR.
It seems we lost [MinimumPerlFast] in the recent re-structuring of dist.ini. I have added it back.
I assume that was not intentional.

Many Thanks.
Best Regards,
Mohammad S Anwar